### PR TITLE
Related issues

### DIFF
--- a/Products/Poi/browser/configure.zcml
+++ b/Products/Poi/browser/configure.zcml
@@ -1,5 +1,6 @@
 <configure
    xmlns="http://namespaces.zope.org/five"
+   xmlns:zope="http://namespaces.zope.org/zope"
    xmlns:browser="http://namespaces.zope.org/browser">
 
   <include file="notifications.zcml" />
@@ -92,5 +93,39 @@
      permission="zope2.View"
      class=".response.Download"
      />
+     
+  <!-- related issues -->
+  
+  <!-- was refbrowserhelper -->
+  <browser:page
+      name="issuerefhelper"
+      permission="zope2.Public"
+      for="Products.Poi.interfaces.IIssue"
+      class=".related.ReferenceBrowserHelperView"
+      />
+ 
+  <!-- was refbrowser_popup -->
+  <browser:page
+      name="issueref_popup"
+      permission="zope2.Public"
+      for="*"
+      class=".related.ReferenceBrowserPopup"
+      />
+
+  <!-- was refbrowser_querycatalog -->
+  <browser:page
+      name="issueref_querycatalog"
+      permission="zope2.Public"
+      for="*"
+      class=".related.QueryCatalogView"
+      />
+
+  <!-- was popup -->
+  <zope:adapter
+      for="Products.Five.BrowserView"
+      factory=".related.default_popup_template"
+      name="issuepopup"
+      provides="zope.formlib.namedtemplate.INamedTemplate"
+      />
 
 </configure>

--- a/Products/Poi/browser/configure.zcml
+++ b/Products/Poi/browser/configure.zcml
@@ -101,6 +101,7 @@
       name="issuerefhelper"
       permission="zope2.Public"
       for="Products.Poi.interfaces.IIssue"
+      allowed_interface="archetypes.referencebrowserwidget.interfaces.IReferenceBrowserHelperView"
       class=".related.ReferenceBrowserHelperView"
       />
  

--- a/Products/Poi/browser/related.py
+++ b/Products/Poi/browser/related.py
@@ -193,6 +193,8 @@ class ReferenceBrowserPopup(BrowserView):
         self.at_url = urllib.quote(request.get('at_url'))
         self.fieldName = request.get('fieldName')
         self.fieldRealName = request.get('fieldRealName')
+        self.search_id_text = request.get('searchValueID', '')
+        self.search_tag_text = request.get('searchValueTag', '')
         self.search_text = request.get('searchValue', '')
 
         base_props = getToolByName(aq_inner(context), 'base_properties', None)
@@ -227,7 +229,9 @@ class ReferenceBrowserPopup(BrowserView):
         self.multiValued = int(self.field.multiValued)
         self.search_index = self.request.get('search_index',
                                              self.widget.default_search_index)
-        self.request.set(self.search_index, self.search_text)
+        self.request.set("Title", self.search_text)
+        self.request.set("Subject", self.search_tag_text)
+        self.request.set("id", self.search_id_text)
 
         base_query = self.widget.getBaseQuery(self.at_obj, self.field)
         self.allowed_types = base_query.get('portal_type', '')
@@ -241,9 +245,9 @@ class ReferenceBrowserPopup(BrowserView):
         # with javascript
         self.close_window = int(not self.field.multiValued or
                                 self.widget.force_close_on_insert)
-        popup_name = getattr(self.widget, 'popup_name', 'popup')
+        popup_name = getattr(self.widget, 'popup_name', 'issuepopup')
         self.template = getAdapter(self, namedtemplate.INamedTemplate,
-                                   name=popup_name or 'popup')
+                                   name=popup_name or 'issuepopup')
         self.browsable_types = self.widget.browsable_types
         self._updated = True
 
@@ -264,10 +268,12 @@ class ReferenceBrowserPopup(BrowserView):
         assert self._updated
         result = []
         qc = getMultiAdapter((self.context, self.request),
-                             name='refbrowser_querycatalog')
-        if self.widget.show_results_without_query or self.search_text:
+                             name='issueref_querycatalog')
+        if self.widget.show_results_without_query or self.search_text or \
+           self.search_id_text or self.search_tag_text:
             result = (self.widget.show_results_without_query or \
-                      self.search_text) and \
+                      self.search_text or self.search_id_text or \
+                      self.search_tag_text) and \
                       qc(search_catalog=self.widget.search_catalog)
 
             self.has_queryresults = bool(result)

--- a/Products/Poi/browser/related.py
+++ b/Products/Poi/browser/related.py
@@ -229,7 +229,7 @@ class ReferenceBrowserPopup(BrowserView):
         self.multiValued = int(self.field.multiValued)
         self.search_index = self.request.get('search_index',
                                              self.widget.default_search_index)
-        self.request.set("Title", self.search_text)
+        self.request.set("SearchableText", self.search_text)
         self.request.set("Subject", self.search_tag_text)
         self.request.set("id", self.search_id_text)
 

--- a/Products/Poi/browser/related.py
+++ b/Products/Poi/browser/related.py
@@ -1,0 +1,375 @@
+from types import ListType, TupleType
+import urllib
+import re
+
+import zope.interface
+
+from zope.component import getAdapter
+from zope.component import getMultiAdapter, queryMultiAdapter
+from zope.i18nmessageid import MessageFactory
+from zope.formlib import namedtemplate
+
+from Acquisition import aq_inner
+from Acquisition import aq_base
+
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from Products.Five import BrowserView
+
+try:
+    # Zope >= 2.13
+    from AccessControl.security import checkPermission
+    checkPermission   # pyflakes
+except ImportError:
+    from Products.Five.security import checkPermission
+
+from Products.ZCTextIndex.ParseTree import ParseError
+
+from plone.app.form._named import named_template_adapter
+
+from Products.Archetypes.config import REFERENCE_CATALOG
+from Products.CMFCore.utils import getToolByName
+try:
+    from plone.uuid.interfaces import IUUID
+    HAS_UUID = True
+except ImportError:
+    HAS_UUID = False
+from Products.CMFPlone.PloneBatch import Batch
+
+from archetypes.referencebrowserwidget import utils
+from archetypes.referencebrowserwidget.interfaces import IFieldRelation
+from archetypes.referencebrowserwidget.interfaces import \
+        IReferenceBrowserHelperView
+
+default_popup_template = named_template_adapter(
+    ViewPageTemplateFile('related_popup.pt'))
+
+PMF = MessageFactory('plone')
+
+class ReferenceBrowserHelperView(BrowserView):
+    """ A helper view for the reference browser widget.
+
+        The main purpose of this view is to move code out of the
+        referencebrowser.pt template. This template needs to be in skins
+        and can not be a view, since it is macro widget for Archetypes.
+    """
+
+    zope.interface.implements(IReferenceBrowserHelperView)
+
+    def getFieldRelations(self, field, value=None):
+        """ Query relations of a field and a context.
+
+            Return a list of objects. If the value parameter
+            is supported it needs to be a list of UIDs.
+        """
+        if not value:
+            return queryMultiAdapter((self.context, field),
+                                     interface=IFieldRelation, default=[])
+        else:
+            if isinstance(value, basestring):
+                value = [value]
+            if type(value) != ListType and type(value) != TupleType:
+                return []
+            catalog = getToolByName(aq_inner(self.context), REFERENCE_CATALOG)
+            return [catalog.lookupObject(uid) for uid in value if uid]
+
+    def getUidFromReference(self, ref):
+        """ Helper to get UID in restricted code without having rights to
+            access the object
+        """
+        uid = None
+        if HAS_UUID:
+            uid = IUUID(ref, None)
+        if uid is None and hasattr(aq_base(ref), 'UID'):
+            uid = ref.UID()
+        return uid
+
+    def getStartupDirectory(self, field):
+        """ Return the URL to the startup directory. """
+        widget = field.widget
+        directory = widget.getStartupDirectory(self.context, field)
+        return utils.getStartupDirectory(self.context, directory)
+
+    def getPortalPath(self):
+        tools = getMultiAdapter((self.context, self.request),
+                                name='plone_tools')
+        return tools.url().getPortalPath()
+
+    def getAtURL(self):
+        context = aq_inner(self.context)
+        return urllib.quote('/'.join(context.getPhysicalPath()))
+
+    def canView(self, obj):
+        return checkPermission('zope2.View', obj)
+
+
+class QueryCatalogView(BrowserView):
+
+    def __call__(self, show_all=0,
+                 quote_logic=0,
+                 quote_logic_indexes=['SearchableText'],
+                 search_catalog=None):
+
+        results = []
+        catalog = utils.getSearchCatalog(aq_inner(self.context),
+                                         search_catalog)
+        indexes = catalog.indexes()
+        query = {}
+        show_query = show_all
+        second_pass = {}
+
+        purl_tool = getToolByName(self.context, 'portal_url')
+        portal_path = purl_tool.getPortalPath()
+
+        for k, v in self.request.items():
+            if v and k in indexes:
+                if type(v) == str and v.strip().lower().startswith('path:'):
+                    # Searching for exact path enabled! This will return the
+                    # item on the specified path and all items in its subtree
+                    # NOTE: Multiple spaces, slashes and/or a trailing slash in
+                    # the path, while easily overlooked by users, might cause
+                    # no results to be found. Let's take care of this for the
+                    # convenience of the user. Besides, we need to strip
+                    # 'path:' from the path string.
+                    path = re.sub("/{2,}", "/", v.strip()[5:]).rstrip("/")
+
+                    if not path.startswith("/"):
+                        path = "/" + path
+
+                    # Since we might be in a virtual-hosting environment, we
+                    # need to prepend the portal path if not present yet
+                    if not path.startswith(portal_path):
+                        path = portal_path + path
+
+                    d = {"path": {"query": path}}
+                else:
+                    if quote_logic and k in quote_logic_indexes:
+                        v = utils.quotequery(v)
+                    d = {k: v}
+                query.update(d)
+                show_query = 1
+
+            elif k.endswith('_usage'):
+                key = k[:-6]
+                param, value = v.split(':')
+                second_pass[key] = {param: value}
+            elif k in ('sort_on', 'sort_order', 'sort_limit'):
+                query.update({k: v})
+
+        for k, v in second_pass.items():
+            qs = query.get(k)
+            if qs is None:
+                continue
+            query[k] = q = {'query': qs}
+            q.update(v)
+
+# doesn't normal call catalog unless some field has been queried
+# against. if you want to call the catalog _regardless_ of whether
+# any items were found, then you can pass show_all=1.
+
+        if show_query:
+            try:
+                results = catalog(**query)
+            except ParseError:
+                pass
+
+        return results
+
+BORDERCOLOR = '#8cacbb'
+FONTFAMILY = '"Lucida Grande", Verdana, Lucida, Helvetica, Arial, sans-serif'
+DISCREETCOLOR = '#76797c'
+
+
+class ReferenceBrowserPopup(BrowserView):
+    """ View class of Popup window """
+
+    has_queryresults = True
+    has_brain = False
+    brainuid = None
+    _updated = False
+
+    def __init__(self, context, request):
+        super(ReferenceBrowserPopup, self).__init__(context, request)
+
+        self.at_url = urllib.quote(request.get('at_url'))
+        self.fieldName = request.get('fieldName')
+        self.fieldRealName = request.get('fieldRealName')
+        self.search_text = request.get('searchValue', '')
+
+        base_props = getToolByName(aq_inner(context), 'base_properties', None)
+        if base_props is not None:
+
+            self.discreetColor = getattr(base_props, 'discreetColor',
+                    DISCREETCOLOR)
+        else:
+            # XXX This concept has changed in Plone 4.0
+            self.discreetColor = DISCREETCOLOR
+
+    def __call__(self):
+        self.update()
+        return self.template()
+
+    def update(self):
+        context = aq_inner(self.context)
+        self.portal_url = getToolByName(context, 'portal_url')()
+        catalog = getToolByName(context, 'portal_catalog')
+        at_result = catalog.searchResults(dict(path={'query': self.at_url,
+                                                     'depth': 0}))
+        at_brain = len(at_result) == 1 and at_result[0] or None
+        if at_brain:
+            self.at_obj = at_brain.getObject()
+            self.has_brain = True
+            self.brainuid = at_brain.UID
+        else:
+            self.at_obj = context.restrictedTraverse(
+                    urllib.unquote(self.at_url))
+        self.field = self.at_obj.Schema()[self.fieldRealName]
+        self.widget = self.field.widget
+        self.multiValued = int(self.field.multiValued)
+        self.search_index = self.request.get('search_index',
+                                             self.widget.default_search_index)
+        self.request.set(self.search_index, self.search_text)
+
+        base_query = self.widget.getBaseQuery(self.at_obj, self.field)
+        self.allowed_types = base_query.get('portal_type', '')
+        if not self.allowed_types:
+            base_query.pop('portal_type')
+
+        if base_query.keys():
+            self.request.form.update(base_query)
+
+        # close_window needs to be int, since it is used
+        # with javascript
+        self.close_window = int(not self.field.multiValued or
+                                self.widget.force_close_on_insert)
+        popup_name = getattr(self.widget, 'popup_name', 'popup')
+        self.template = getAdapter(self, namedtemplate.INamedTemplate,
+                                   name=popup_name or 'popup')
+        self.browsable_types = self.widget.browsable_types
+        self._updated = True
+
+    @property
+    def search_catalog(self):
+        assert self._updated
+        return utils.getSearchCatalog(aq_inner(self.context),
+                                      self.widget.search_catalog)
+
+    @property
+    def filtered_indexes(self):
+        assert self._updated
+        indexes = self.search_catalog.indexes()
+        avail = self.widget.available_indexes
+        return [index for index in indexes if not avail or index in avail]
+
+    def getResult(self):
+        assert self._updated
+        result = []
+        qc = getMultiAdapter((self.context, self.request),
+                             name='refbrowser_querycatalog')
+        if self.widget.show_results_without_query or self.search_text:
+            result = (self.widget.show_results_without_query or \
+                      self.search_text) and \
+                      qc(search_catalog=self.widget.search_catalog)
+
+            self.has_queryresults = bool(result)
+
+        elif self.widget.allow_browse:
+            ploneview = getMultiAdapter((self.context, self.request),
+                                        name="plone")
+            folder = ploneview.getCurrentFolder()
+            self.request.form['path'] = {
+                              'query': '/'.join(folder.getPhysicalPath()),
+                              'depth':1}
+            self.request.form['portal_type'] = []
+            if 'sort_on' in self.widget.base_query:
+                self.request.form['sort_on'] = self.widget.base_query['sort_on']
+            else:
+                self.request.form['sort_on'] = 'getObjPositionInParent'
+
+            result = qc(search_catalog=self.widget.search_catalog)
+        else:
+            result = []
+        b_size = int(self.request.get('b_size', 20))
+        b_start = int(self.request.get('b_start', 0))
+
+        return Batch(result, b_size, b_start, orphan=1)
+
+    def breadcrumbs(self, startup_directory=None):
+        assert self._updated
+        context = aq_inner(self.context)
+        portal_state = getMultiAdapter((context, self.request),
+                                       name=u'plone_portal_state')
+        bc_view = context.restrictedTraverse('@@breadcrumbs_view')
+        crumbs = bc_view.breadcrumbs()
+
+        if not self.widget.restrict_browsing_to_startup_directory:
+            newcrumbs = [{'Title': PMF('Home'),
+                          'absolute_url': self.genRefBrowserUrl(
+                                portal_state.navigation_root_url())}]
+        else:
+            # display only crumbs into startup directory
+            startup_dir_url = startup_directory or \
+                utils.getStartupDirectory(context,
+                        self.widget.getStartupDirectory(context, self.field))
+            newcrumbs = []
+            crumbs = [c for c in crumbs \
+                             if c['absolute_url'].startswith(startup_dir_url)]
+
+        for c in crumbs:
+            c['absolute_url'] = self.genRefBrowserUrl(c['absolute_url'])
+            newcrumbs.append(c)
+
+        return newcrumbs
+
+    def genRefBrowserUrl(self, urlbase):
+        assert self._updated
+        return "%s/%s?fieldName=%s&fieldRealName=%s&at_url=%s" % (
+       urlbase, self.__name__, self.fieldName, self.fieldRealName, self.at_url)
+
+    def getUid(self, item):
+        assert self._updated
+        return getattr(aq_base(item), 'UID', None)
+
+    def isNotSelf(self, item):
+        assert self._updated
+
+        def safe_get_object(item):
+            """ Return an object from the catalog, if it exists """
+            try:
+                return item.getObject()
+            except AttributeError:
+                return None
+
+        return self.has_brain and self.getUid(item) != self.brainuid or \
+               safe_get_object(item) != self.at_obj
+
+    def isReferencable(self, item):
+        assert self._updated
+        item_referenceable = not self.allowed_types or \
+            item.portal_type in self.allowed_types
+        filter_review_states = self.widget.only_for_review_states is not None
+        review_state_allows = True
+        if filter_review_states:
+            review_state_allows = item.review_state in \
+                (self.widget.only_for_review_states or ())
+        return self.getUid(item) and item_referenceable and \
+               review_state_allows and self.isNotSelf(item)
+
+    def isBrowsable(self, item):
+        if not self.browsable_types:
+            return item.is_folderish
+        else:
+            return item.portal_type in self.browsable_types
+
+    def title_or_id(self, item):
+        assert self._updated
+        item = aq_base(item)
+        return getattr(item, 'Title', '') or getattr(item, 'getId', '')
+
+    def preview_url(self, item):
+        portal_properties = getMultiAdapter((self.context, self.request),
+                                            name=u'plone_tools').properties()
+        site_properties = portal_properties.site_properties
+        types_use_view = site_properties.typesUseViewActionInListings
+        if item.portal_type in types_use_view:
+            return item.getURL()+'/view'
+        return item.getURL()

--- a/Products/Poi/browser/related_popup.pt
+++ b/Products/Poi/browser/related_popup.pt
@@ -1,0 +1,257 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      i18n:domain="atreferencebrowserwidget">
+  <head>
+  </head>
+  <body
+      class="popup atrefbrowser"
+      id="atrefbrowserpopup"
+      style="font-size: 150% !important"
+      tal:define="fieldName view/fieldName;
+                  multiValued view/multiValued;
+                  fieldRealName view/fieldRealName;
+                  at_obj nocall:view/at_obj;
+                  widget nocall:view/widget;
+                  title python:widget.Label(at_obj);
+                  search_index view/search_index;
+                  search_text view/search_text;
+                  available_indexes widget/available_indexes;
+                  allow_browse widget/allow_browse;
+                  image_portal_types widget/image_portal_types;
+                  image_method widget/image_method|string:image_icon;
+                  ">
+
+    <div id="atrefbrowserpopup-top-helper"
+         tal:condition="widget/top_popup_helper"
+
+         tal:content="structure widget/top_popup_helper"
+         i18n:translate="" />
+
+    <div id="messageWrapper" style="position: relative">
+      <div style="position: absolute; width: 100%">
+        <dl id="messageAdded" class="portalMessage info"
+            style="display:none; margin-top:0">
+          <dt i18n:translate="referencebrowser_text_added_reference"
+              >Added</dt>
+          <dd></dd>
+        </dl>
+      </div>
+      <div style="position: absolute; width: 100%">
+        <dl id="messageRemoved" class="portalMessage info"
+            style="display:none; margin-top:0">
+          <dt i18n:translate="referencebrowser_text_removed_reference"
+              >Removed</dt>
+          <dd></dd>
+        </dl>
+      </div>
+    </div>
+
+    <!-- Search form -->
+    <form action="search" method="post" name="search" id="search"
+          style="text-align: right;"          tal:attributes="action request/getURL">
+     <tal:formactions
+          tal:condition="widget/allow_search">
+      <div class="field" >
+        <tal:indexes condition="widget/show_indexes">
+        <label i18n:translate="referencebrowser_search_index_label">
+             Search index
+        </label>
+        <select name="search_index" id="indexSelector">
+          <tal:indexes tal:repeat="index view/filtered_indexes">
+            <option value="" selected=""
+                tal:attributes="
+                    value index;
+                    selected python:index==search_index and 'selected' or ''"
+                tal:content="python:available_indexes[index]"
+                tal:condition="python:available_indexes.has_key(index)"
+                />
+
+            <option value="" selected=""
+                tal:attributes="
+                    value index;
+                    selected python:index==search_index and 'selected' or ''"
+                tal:content="index"
+                tal:condition="python:not available_indexes.has_key(index)"
+                />
+          </tal:indexes>
+        </select>
+        </tal:indexes>
+
+        <input type="text"
+               id="searchGadget"
+               name="searchValue"
+               size="25"
+               title="Search Site"
+               placeholder="Search Site"
+               value=""
+               i18n:attributes="title referencebrowser_search_site;
+                                placeholder referencebrowser_search_site"
+               tal:attributes="value search_text;"
+               />
+        <input class="searchButton"
+               type="submit"
+               name="submit"
+               value="Search"
+               i18n:domain="plone"
+               i18n:attributes="value label_search;"
+               />
+      </div>
+     </tal:formactions>
+
+     <!-- add these to make sure that after a search result, we still have
+          these paremeters -->
+     <input type="hidden" name="fieldName" value=""
+            tal:attributes="value fieldName" />
+     <input type="hidden" name="fieldRealName" value=""
+            tal:attributes="value fieldRealName" />
+     <input type="hidden" name="at_url" value=""
+            tal:attributes="value view/at_url" />
+     <input type="hidden" name="multiValued" value=""
+            tal:attributes="value multiValued" />
+     <input type="hidden" name="close_window" value=""
+            tal:attributes="value view/close_window" />
+    </form>
+    <!-- actual list of objects, either searchresults or folder contents -->
+    <div id="atrbResults" tal:define="batch view/getResult;">
+
+      <!-- history -->
+      <div tal:condition="python:widget.history_length > 0" style="float: right; clear: right;">
+        <form action="referencebrowser_popup" name="history" id="history">
+          <label for="path"
+                 i18n:translate="referencebrowser_history">History</label>
+          <select name="path">
+          </select>
+          <noscript>
+              <input class="context" type="button" value="Go" name="go"
+                     i18n:attributes="value label_go" />
+          </noscript>
+        </form>
+      </div>
+
+      <!-- breadcrumbs -->
+      <div tal:condition= "python:search_text=='' and allow_browse"
+           tal:define="isRTL here/@@plone_portal_state/is_rtl;"
+           style="margin-bottom: 1em">
+
+        <span id="breadcrumbs-you-are-here" i18n:domain="plone"
+            i18n:translate="you_are_here">You are here:</span>
+        <tal:crumbs tal:repeat="crumb view/breadcrumbs">
+
+        <a class="browsesite"
+            tal:attributes="href crumb/absolute_url;
+                            rel crumb/Title">
+            <span i18n:translate="" tal:content="crumb/Title">
+              Breadcrumb Title
+            </span>
+          </a>
+
+          <span tal:condition="not: repeat/crumb/end"
+                class="breadcrumbSeparator">
+            <tal:ltr condition="not: isRTL">&rarr;</tal:ltr>
+            <tal:rtl condition="isRTL">&larr;</tal:rtl>
+          </span>
+
+        </tal:crumbs>
+
+      </div>
+
+      <!-- object list -->
+      <p tal:condition="not:view/has_queryresults"
+         id="atrbNoResults"
+         i18n:translate="referencebrowser_no_items_found">No items found.</p>
+
+      <table class="group" width="100%" cellspacing="0" cellpadding="2"
+         tal:condition="batch"
+         id="atrbResultsTable">
+         <colgroup>
+           <col width="20px" />
+           <col />
+         </colgroup>
+    <tbody>
+      <tal:results tal:define="plone_view context/@@plone;
+                               normalizeString nocall:plone_view/normalizeString;"
+                   tal:repeat="item batch">
+        <tal:row
+        tal:define="
+            uid python:view.getUid(item);
+            isNotSelf python:view.isNotSelf(item);
+            referenceable python:view.isReferencable(item);
+            browsable python:allow_browse and view.isBrowsable(item);
+            title_or_id python:view.title_or_id(item);
+            color view/discreetColor;">
+
+          <tr tal:define="oddrow repeat/item/odd"
+          tal:attributes="class python:oddrow and 'even' or 'odd'">
+
+        <td>
+          <tal:referenceable tal:condition="referenceable">
+            <input type="checkbox" class="insertreference" tal:attributes="rel uid; id uid" />
+          </tal:referenceable>
+        </td>
+
+        <td tal:condition="image_portal_types">
+          <img tal:condition="python: item.Type in image_portal_types"
+               tal:attributes="src string:${item/getURL}/$image_method"
+               />
+        </td>
+        <td tal:attributes="class python:'contenttype-' + normalizeString(item.portal_type)">
+          <img tal:define="icon item/getIcon"
+               tal:condition="icon"
+               tal:attributes="src string:${view/portal_url}/$icon" />
+          <a class="browsesite" tal:condition="browsable"
+             tal:attributes="
+             href python:view.genRefBrowserUrl(item.getURL());
+             rel item/Title">
+            <label tal:condition="referenceable"
+                   tal:attributes="for uid;"
+                   tal:content="title_or_id">Title</label>
+            <span tal:condition="not:referenceable" tal:content="title_or_id" />
+          </a>
+          <tal:foldercheck tal:condition="
+              python:not(browsable and isNotSelf)" >
+            <label tal:condition="referenceable"
+                   tal:attributes="for uid;"
+                   tal:content="title_or_id">Title
+            </label>
+            <span tal:condition="not:referenceable"
+                  tal:content="title_or_id" />
+          </tal:foldercheck>
+          <a class="discreet"
+		     tal:condition="referenceable"
+			 onclick="window.open(jQuery(this).attr('href'));return false;"
+			 tal:attributes="href python:view.preview_url(item)">
+          	(<span i18n:translate="" i18n:domain="plone">View</span>)
+          </a>
+
+          <div tal:condition="widget/show_review_state">
+            <span tal:define="state item/review_state"
+              tal:attributes="class python:'state-' + normalizeString(state)"
+              i18n:translate="" i18n:domain="plone"
+              tal:content="state"
+              />
+          </div>
+
+          <div class="additionalInfo"
+               tal:content="
+              structure item/additionalReferenceInfo | nothing"
+              />
+        </td>
+          </tr>
+        </tal:row>
+      </tal:results>
+    </tbody>
+      </table>
+
+      <tal:var tal:define="template_id view/__name__">
+    <div metal:use-macro="here/batch_macros/macros/navigation" />
+      </tal:var>
+
+    <div id="atrefbrowserpopup-bottom-helper"
+         tal:condition="widget/bottom_popup_helper"
+         tal:content="structure widget/bottom_popup_helper"
+         i18n:translate="" />
+
+    </div>
+  </body>
+</html>

--- a/Products/Poi/browser/related_popup.pt
+++ b/Products/Poi/browser/related_popup.pt
@@ -107,7 +107,7 @@
                name="searchValue"
                size="25"
                title="Search Site"
-               placeholder="Search Issue Titles"
+               placeholder="Search Issue Text"
                value=""
                i18n:attributes="title referencebrowser_search_site;
                                 placeholder referencebrowser_search_site"

--- a/Products/Poi/browser/related_popup.pt
+++ b/Products/Poi/browser/related_popup.pt
@@ -16,6 +16,8 @@
                   title python:widget.Label(at_obj);
                   search_index view/search_index;
                   search_text view/search_text;
+                  search_tag_text view/search_tag_text;
+                  search_id_text view/search_id_text;
                   available_indexes widget/available_indexes;
                   allow_browse widget/allow_browse;
                   image_portal_types widget/image_portal_types;
@@ -79,11 +81,33 @@
         </tal:indexes>
 
         <input type="text"
-               id="searchGadget"
+               id="search-ids"
+               name="searchValueID"
+               size="25"
+               title="Search Site"
+               placeholder="Search Issue IDs"
+               value=""
+               i18n:attributes="title referencebrowser_search_site;
+                                placeholder referencebrowser_search_site"
+               tal:attributes="value search_id_text;"
+               />
+        <input type="text"
+               id="search-tags"
+               name="searchValueTag"
+               size="25"
+               title="Search Site"
+               placeholder="Search Issue Tags"
+               value=""
+               i18n:attributes="title referencebrowser_search_site;
+                                placeholder referencebrowser_search_site"
+               tal:attributes="value search_tag_text;"
+               />
+        <input type="text"
+               id="search-titles"
                name="searchValue"
                size="25"
                title="Search Site"
-               placeholder="Search Site"
+               placeholder="Search Issue Titles"
                value=""
                i18n:attributes="title referencebrowser_search_site;
                                 placeholder referencebrowser_search_site"

--- a/Products/Poi/browser/related_popup.pt
+++ b/Products/Poi/browser/related_popup.pt
@@ -220,16 +220,17 @@
                />
         </td>
         <td tal:attributes="class python:'contenttype-' + normalizeString(item.portal_type)">
-          <img tal:define="icon item/getIcon"
-               tal:condition="icon"
-               tal:attributes="src string:${view/portal_url}/$icon" />
           <a class="browsesite" tal:condition="browsable"
              tal:attributes="
              href python:view.genRefBrowserUrl(item.getURL());
              rel item/Title">
             <label tal:condition="referenceable"
-                   tal:attributes="for uid;"
-                   tal:content="title_or_id">Title</label>
+                   tal:attributes="for uid;">
+                <tal:issue condition="item/id">
+                    #<span tal:replace="item/id">#123</span> --
+                </tal:issue>
+                <tal:title content="title_or_id">Title</tal:title>
+            </label>
             <span tal:condition="not:referenceable" tal:content="title_or_id" />
           </a>
           <tal:foldercheck tal:condition="

--- a/Products/Poi/browser/related_popup.pt
+++ b/Products/Poi/browser/related_popup.pt
@@ -85,7 +85,7 @@
                name="searchValueID"
                size="25"
                title="Search Site"
-               placeholder="Search Issue IDs"
+               placeholder="Search Issue Numbers"
                value=""
                i18n:attributes="title referencebrowser_search_site;
                                 placeholder referencebrowser_search_site"
@@ -136,6 +136,9 @@
      <input type="hidden" name="close_window" value=""
             tal:attributes="value view/close_window" />
     </form>
+
+    <p class="errorMessage" style="font-style: italic; padding: 3px 10px;"></p>
+
     <!-- actual list of objects, either searchresults or folder contents -->
     <div id="atrbResults" tal:define="batch view/getResult;">
 

--- a/Products/Poi/configure.zcml
+++ b/Products/Poi/configure.zcml
@@ -53,6 +53,12 @@
            Products.Archetypes.interfaces.IObjectEditedEvent"
         handler=".events.add_contact_to_issue_watchers"
         />
+        
+  <subscriber
+      for="Products.Poi.interfaces.IIssue
+           Products.Archetypes.interfaces.IObjectEditedEvent"
+        handler=".events.update_references"
+        />
 
   <subscriber
       for="Products.Poi.interfaces.IIssue

--- a/Products/Poi/configure.zcml
+++ b/Products/Poi/configure.zcml
@@ -53,6 +53,12 @@
            Products.Archetypes.interfaces.IObjectEditedEvent"
         handler=".events.add_contact_to_issue_watchers"
         />
+
+  <subscriber
+      for="Products.Poi.interfaces.IIssue
+           Products.Archetypes.interfaces.IObjectInitializedEvent"
+        handler=".events.update_references"
+        />
         
   <subscriber
       for="Products.Poi.interfaces.IIssue

--- a/Products/Poi/content/PoiIssue.py
+++ b/Products/Poi/content/PoiIssue.py
@@ -42,7 +42,6 @@ from Products.Archetypes.atapi import FileField
 from Products.Archetypes.atapi import FileWidget
 from Products.Archetypes.atapi import LinesField
 from Products.Archetypes.atapi import LinesWidget
-from Products.Archetypes.atapi import ReferenceField
 from Products.Archetypes.atapi import RichWidget
 from Products.Archetypes.atapi import Schema
 from Products.Archetypes.atapi import SelectionWidget
@@ -54,6 +53,8 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFDynamicViewFTI.browserdefault import BrowserDefaultMixin
 from Products.CMFPlone.utils import getSiteEncoding
 from Products.CMFPlone.utils import safe_unicode
+from Products.OrderableReferenceField import OrderableReferenceField
+from Products.PopupCalendarWidget.PopupCalendarWidget import PopupCalendarWidget
 from collective.watcherlist.utils import get_member_email
 from plone.memoize import instance
 from zope.interface import implements
@@ -303,15 +304,13 @@ schema = Schema((
         write_permission=permissions.ModifyIssueTags,
         accessor="Subject"
     ),
-    
-    ReferenceField('relatedIssue',
+
+    OrderableReferenceField('relatedIssue',
         multiValued=1,
         relationship='related_issue',
         allowed_types=('PoiIssue'),
         widget=IssueReferenceWidget(
             label=('Related issue(s)'),
-            default_search_index='SearchableText',
-            allow_sorting=1,
             description='Link related issues')),
 
 ))

--- a/Products/Poi/content/PoiIssue.py
+++ b/Products/Poi/content/PoiIssue.py
@@ -306,7 +306,7 @@ schema = Schema((
     
     ReferenceField('relatedIssue',
         multiValued=1,
-        relationship='Rel1',
+        relationship='related_issue',
         allowed_types=('PoiIssue'),
         widget=IssueReferenceWidget(
             label=('Related issue(s)'),

--- a/Products/Poi/content/PoiIssue.py
+++ b/Products/Poi/content/PoiIssue.py
@@ -42,6 +42,7 @@ from Products.Archetypes.atapi import FileField
 from Products.Archetypes.atapi import FileWidget
 from Products.Archetypes.atapi import LinesField
 from Products.Archetypes.atapi import LinesWidget
+from Products.Archetypes.atapi import ReferenceField
 from Products.Archetypes.atapi import RichWidget
 from Products.Archetypes.atapi import Schema
 from Products.Archetypes.atapi import SelectionWidget
@@ -67,6 +68,7 @@ from Products.Poi.config import ISSUE_MIME_TYPES
 from Products.Poi.config import PROJECTNAME
 from Products.Poi.interfaces import IIssue
 from Products.Poi.interfaces import ITracker
+from Products.Poi.widgets import IssueReferenceWidget
 
 wrapper = textwrap.TextWrapper(initial_indent='    ', subsequent_indent='    ')
 logger = logging.getLogger('Poi')
@@ -301,6 +303,16 @@ schema = Schema((
         write_permission=permissions.ModifyIssueTags,
         accessor="Subject"
     ),
+    
+    ReferenceField('relatedIssue',
+        multiValued=1,
+        relationship='Rel1',
+        allowed_types=('PoiIssue'),
+        widget=IssueReferenceWidget(
+            label=('Related issue(s)'),
+            default_search_index='SearchableText',
+            allow_sorting=1,
+            description='Link related issues')),
 
 ))
 

--- a/Products/Poi/events.py
+++ b/Products/Poi/events.py
@@ -175,3 +175,23 @@ def sendResponseNotificationMail(issue):
     # As we take the last response by default, we can keep this simple.
     watchers = IWatcherList(issue)
     watchers.send('new-response-mail')
+
+
+def update_references(object, event=None):
+    """Get list of Related Issues set here, and relate them back
+       Then check the getBRefs to remove references that have been removed
+    """
+    relatedIssues = object.getRelatedIssue()
+    for issue in relatedIssues:
+        others_related = issue.getRelatedIssue()
+        if object not in others_related:
+            others_related.append(object)
+            issue.setRelatedIssue(others_related)
+
+    issuesRelated = object.getBRefs()
+    for issue in issuesRelated:
+        if issue not in object.getRelatedIssue():
+            others_related = issue.getRelatedIssue()
+            if object in others_related:
+                others_related.remove(object)
+                issue.setRelatedIssue(others_related)

--- a/Products/Poi/events.py
+++ b/Products/Poi/events.py
@@ -184,14 +184,17 @@ def update_references(object, event=None):
     relatedIssues = object.getRelatedIssue()
     for issue in relatedIssues:
         others_related = issue.getRelatedIssue()
-        if object not in others_related:
-            others_related.append(object)
-            issue.setRelatedIssue(others_related)
+        if object in others_related:
+            continue
+        others_related.append(object)
+        issue.setRelatedIssue(others_related)
 
-    issuesRelated = object.getBRefs()
+    issuesRelated = object.getBRefs('related_issue')
     for issue in issuesRelated:
-        if issue not in object.getRelatedIssue():
-            others_related = issue.getRelatedIssue()
-            if object in others_related:
-                others_related.remove(object)
-                issue.setRelatedIssue(others_related)
+        if issue in object.getRelatedIssue():
+            continue
+        others_related = issue.getRelatedIssue()
+        if object not in others_related:
+            continue
+        others_related.remove(object)
+        issue.setRelatedIssue(others_related)

--- a/Products/Poi/events.py
+++ b/Products/Poi/events.py
@@ -180,14 +180,20 @@ def sendResponseNotificationMail(issue):
 def update_references(object, event=None):
     """Get list of Related Issues set here, and relate them back
        Then check the getBRefs to remove references that have been removed
+       Sort the issues in descending id order
     """
-    relatedIssues = object.getRelatedIssue()
+    relatedIssues = sorted(object.getRelatedIssue(),
+                           key=lambda issue: int(issue.id),
+                           reverse=True)
+    object.setRelatedIssue(relatedIssues)
     for issue in relatedIssues:
         others_related = issue.getRelatedIssue()
         if object in others_related:
             continue
         others_related.append(object)
-        issue.setRelatedIssue(others_related)
+        issue.setRelatedIssue(sorted(others_related,
+                              key=lambda issue: int(issue.id),
+                              reverse=True))
 
     issuesRelated = object.getBRefs('related_issue')
     for issue in issuesRelated:

--- a/Products/Poi/skins/Poi/issuereference.js
+++ b/Products/Poi/skins/Poi/issuereference.js
@@ -1,0 +1,448 @@
+jQuery(function(jq) {
+
+  // Move the overlay div to be a direct child
+  // of body to avoid IE7 z-index bug.
+  // TODO: load this with prepOverlay to standardize this.
+  jq('[id^=atrb_]').detach().appendTo("body");
+
+  // the overlay itself
+  jq('.addreference').overlay({
+       onBeforeLoad: function() {
+           ov = jq('div#content').data('overlay');
+           // close overlay, if there is one already
+           // we only allow one referencebrowser per time
+           if (ov) {ov.close(); }
+           var wrap = this.getOverlay().find('.overlaycontent');
+           var src = this.getTrigger().attr('src');
+           var srcfilter = src + ' >*';
+           wrap.data('srcfilter', srcfilter);
+           jq('div#content').data('overlay', this);
+           resetHistory();
+           wrap.load(srcfilter, function() {
+               var fieldname = wrap.find('input[name=fieldName]').attr('value');
+               check_referenced_items(fieldname);
+               });
+           },
+       onLoad: function() {
+           widget_id = this.getTrigger().attr('rel').substring(6);
+           disablecurrentrelations(widget_id);
+       }});
+
+  // the breadcrumb-links and the links of the 'tree'-navigati        on
+  jq('[id^=atrb_] a.browsesite', jq('body')[0]).live('click', function(event) {
+      var target = jq(this);
+      var src = target.attr('href');
+      var wrap = target.parents('.overlaycontent');
+      var srcfilter = src + ' >*';
+      pushToHistory(wrap.data('srcfilter'));
+      wrap.data('srcfilter', srcfilter);
+      // the history we are constructing here is destinct from the
+      // srcfilter-history. here we construct a selection-widget, which
+      // is available, if the history_length-parameter is set on the widget
+      // the srcfilter-history is used for storing the URLs to make the
+      // 'Back'-link work.
+      var newoption = '<option value="' + src + '">' +
+          target.attr('rel') + '</option>';
+      refreshOverlay(wrap, srcfilter, newoption);
+      return false;
+      });
+
+  // the links for inserting referencens
+  jq('[id^=atrb_] input.insertreference', jq('body')[0]).live('click', function(event) {
+      var target = jq(this);
+      var wrap = target.parents('.overlaycontent');
+      var fieldname = wrap.find('input[name=fieldName]').attr('value');
+      var multi = wrap.find('input[name=multiValued]').attr('value');
+      var close_window = wrap.find('input[name=close_window]').attr('value');
+      var tablerow = target.parent().parent();
+      var title = tablerow.find('label').html();
+      var uid = target.attr('rel');
+      var messageId;
+      var widget_id_base = 'ref_browser_';
+      if (multi !== '0') {
+        widget_id_base = 'ref_browser_items_';
+      }
+      if (this.checked === true) {
+          refbrowser_setReference(widget_id_base + fieldname,
+                                  uid, title, parseInt(multi));
+          messageId = '#messageAdded';
+          }
+      else {
+          refbrowser_delReference(fieldname, uid);
+          messageId = '#messageRemoved';
+      }
+      if (close_window === '1' && multi != '1') {
+          overlay = jq('div#content').data('overlay');
+          overlay.close();
+      } else {
+          showMessage(messageId, title);
+      };
+      });
+
+
+  // the history menu
+  jq('[id^=atrb_] form#history select[name=path]', jq('body')[0]).live('change', function(event) {
+      var target = jq(this);
+      var wrap = target.parents('.overlaycontent');
+      var src_selector = '[id^=atrb_] form#history ' +
+          'select[name=path] :selected';
+      var src = jq(src_selector).attr('value');
+      var srcfilter = src + ' >*';
+      refreshOverlay(wrap, srcfilter, '');
+      return false;
+      });
+
+  // the pagination links
+  jq('[id^=atrb_] .listingBar a', jq('body')[0]).live('click', function(event) {
+      var target = jq(this);
+      var src = target.attr('href');
+      var wrap = target.parents('.overlaycontent');
+      var srcfilter = src + ' >*';
+      refreshOverlay(wrap, srcfilter, '');
+      return false;
+      });
+
+
+
+  function do_atref_search(event) {
+      event.preventDefault();
+      var target = jq(event.target);
+      var src = target.parents('form').attr('action');
+      var wrap = target.parents('.overlaycontent');
+      var fieldname = wrap.find('input[name=fieldName]').attr('value');
+      var fieldrealname = wrap.find('input[name=fieldRealName]').attr('value');
+      var at_url = wrap.find('input[name=at_url]').attr('value');
+      var searchvalue = encodeURI(wrap.find('input[name=searchValue]').attr('value'));
+      var search_index = wrap.find('select[name=search_index]').attr('value');
+      var multi = wrap.find('input[name=multiValued]').attr('value');
+      var close_window = wrap.find('input[name=close_window]').attr('value');
+      qs = 'searchValue=' + searchvalue;
+      // if a search_index is defined (a dropdown list of selectable indexes next to the search input), we insert it to qs
+      if (search_index) {
+          qs += '&search_index=' + search_index;
+          };
+      qs += '&fieldRealName=' + fieldrealname +
+        '&fieldName=' + fieldname + '&multiValued=' + multi +
+        '&close_window' + close_window + '&at_url=' + at_url;
+      var srcfilter = src + '?' + qs + ' >*';
+      pushToHistory(wrap.data('srcfilter'));
+      wrap.data('srcfilter', srcfilter);
+      refreshOverlay(wrap, srcfilter, '');
+      return false;
+      }
+
+  // the search form
+  // // This does not catch form submission via enter in FF but does in IE
+  jq('[id^=atrb_] form#search').live('submit', do_atref_search);
+  //     // This catches form submission in FF
+  jq('[id^=atrb_] form#search input[name=submit]',
+      jq('body')[0]).live('click',do_atref_search);
+
+  function disablecurrentrelations (widget_id) {
+     jq('ul#' + widget_id + ' :input').each(
+         function (intIndex) {
+           uid = jq(this).attr('value');
+           cb = jq('input[rel=' + uid + ']');
+           cb.attr('disabled', 'disabled');
+           cb.attr('checked', 'checked');
+         });
+  }
+
+
+  // function to return a reference from the popup window back into the widget
+  function refbrowser_setReference(widget_id, uid, label, multi)
+  {
+      var element = null,
+          label_element = null,
+          current_values = null,
+          i = null,
+          list = null,
+          li = null,
+          input = null,
+          up_element = null,
+          down_element = null,
+          container = null,
+          fieldname = null;
+      // differentiate between the single and mulitselect widget
+      // since the single widget has an extra label field.
+      if (multi === 0) {
+          jq('#' + widget_id).attr('value', uid);
+          jq('#' + widget_id + '_label').attr('value', label);
+      } else {
+          // check if the item isn't already in the list
+          current_values = jq('#' + widget_id + ' input');
+          for (i = 0; i < current_values.length; i++) {
+              if (current_values[i].value === uid) {
+                  return false;
+              }
+          }
+          // now add the new item
+          var fieldname = widget_id.substr('ref_browser_items_'.length);
+          list = document.getElementById(widget_id);
+          // add ul-element to DOM, if it is not there
+          if (list === null) {
+              container = jq('#archetypes-fieldname-' + fieldname +
+                             ' input + div');
+              if (!container.length) {
+                  // fix for Plone 3.3 collections, with a weird widget-id
+                  container = jq('#archetypes-fieldname-value input + div');
+              }
+              container.after(
+                 '<ul class="visualNoMarker" id="' + widget_id + '"></ul>');
+              list = document.getElementById(widget_id);
+          }
+          li = document.createElement('li');
+          label_element = document.createElement('label');
+          input = document.createElement('input');
+          input.type = 'checkbox';
+          input.value = uid;
+          input.checked = true;
+          input.name = fieldname + ':list';
+          label_element.appendChild(input);
+          label_element.appendChild(document.createTextNode(' ' + label));
+          li.appendChild(label_element);
+          li.id = 'ref-' + fieldname + '-' + current_values.length;
+
+          sortable = jq('input[name=' + fieldname + '-sortable]').attr('value');
+          if (sortable === '1') {
+            up_element = document.createElement('a');
+            up_element.title = 'Move Up';
+            up_element.href = '';
+            up_element.innerHTML = '&#x25b2;';
+            up_element.onclick = function () {
+                refbrowser_moveReferenceUp(this);
+                return false;
+            };
+
+            li.appendChild(up_element);
+
+            down_element = document.createElement('a');
+            down_element.title = 'Move Down';
+            down_element.href = '';
+            down_element.innerHTML = '&#x25bc;';
+            down_element.onclick = function () {
+                refbrowser_moveReferenceDown(this);
+                return false;
+            };
+
+            li.appendChild(down_element);
+          }
+          list.appendChild(li);
+
+          // fix on IE7 - check *after* adding to DOM
+          input.checked = true;
+      }
+  }
+
+  // remove the item for the uid from the reference widget
+  function refbrowser_delReference(fieldname, uid) {
+      var selector = 'input[value="' + uid + '"][name="' + fieldname + ':list"]',
+          inputs = jq(selector);
+      inputs.closest('li').remove();
+  }
+
+  // function to clear the reference field or remove items
+  // from the multivalued reference list.
+  function refbrowser_removeReference(widget_id, multi)
+  {
+      var x = null,
+          element = null,
+          label_element = null,
+          list = null;
+
+      if (multi) {
+          list = document.getElementById(widget_id);
+          for (x = list.length - 1; x >= 0; x--) {
+              if (list[x].selected) {
+                  list[x] = null;
+              }
+          }
+          for (x = 0; x < list.length; x++) {
+              list[x].selected = 'selected';
+          }
+      } else {
+          jq('#' + widget_id).attr('value', "");
+          jq('#' + widget_id + '_label').attr('value', "");
+      }
+  }
+
+  function refbrowser_moveReferenceUp(self)
+  {
+      var elem = self.parentNode,
+          eid = null,
+          pos = null,
+          widget_id = null,
+          newelem = null,
+          prevelem = null,
+          arrows = null,
+          cbs = null;
+      if (elem === null) {
+          return false;
+      }
+      eid = elem.id.split('-');
+      pos = eid.pop();
+      if (pos === "0") {
+          return false;
+      }
+      widget_id = eid.pop();
+      newelem = elem.cloneNode(true);
+
+      //Fix: (IE keep the standard value)
+      cbs = newelem.getElementsByTagName("input");
+      if (cbs.length > 0) {
+          cbs[0].checked = elem.getElementsByTagName("input")[0].checked;
+      }
+
+      prevelem = document.getElementById('ref-' + widget_id + '-' + (pos - 1));
+
+      // up arrow
+      arrows = newelem.getElementsByTagName("a");
+      arrows[0].onclick = function () {
+          refbrowser_moveReferenceUp(this);
+          return false;
+      };
+      // down arrow
+      arrows[1].onclick = function () {
+          refbrowser_moveReferenceDown(this);
+          return false;
+      };
+
+      elem.parentNode.insertBefore(newelem, prevelem);
+      elem.parentNode.removeChild(elem);
+      newelem.id = 'ref-' + widget_id + '-' + (pos - 1);
+      prevelem.id = 'ref-' + widget_id + '-' + pos;
+  }
+
+  function refbrowser_moveReferenceDown(self)
+  {
+      var elem = self.parentNode,
+          eid = null,
+          pos = null,
+          widget_id = null,
+          current_values = null,
+          newelem = null,
+          nextelem = null,
+          cbs = null,
+          arrows = null;
+      if (elem === null) {
+          return false;
+      }
+      eid = elem.id.split('-');
+      pos = parseInt(eid.pop(), 10);
+      widget_id = eid.pop();
+      current_values = jq('#ref_browser_items_' + widget_id + ' input');
+      if ((pos + 1) === current_values.length) {
+          return false;
+      }
+
+      newelem = elem.cloneNode(true);
+      //Fix: (IE keep the standard value)
+      cbs = newelem.getElementsByTagName("input");
+      if (cbs.length > 0) {
+          cbs[0].checked = elem.getElementsByTagName("input")[0].checked;
+      }
+
+      // up img
+      arrows = newelem.getElementsByTagName("a");
+      arrows[0].onclick = function () {
+          refbrowser_moveReferenceUp(this);
+          return false;
+      };
+      // down img
+      arrows[1].onclick = function () {
+          refbrowser_moveReferenceDown(this);
+          return false;
+      };
+
+      nextelem = document.getElementById('ref-' + widget_id + '-' + (pos + 1));
+
+      elem.parentNode.insertBefore(newelem, nextelem.nextSibling);
+      elem.parentNode.removeChild(elem);
+      newelem.id = 'ref-' + widget_id + '-' + (pos + 1);
+      nextelem.id = 'ref-' + widget_id + '-' + pos;
+  }
+
+  function showMessage(messageId, text) {
+      var template = jq(messageId).parent(),
+          message_div = template.clone(),
+          message = message_div.children(),
+          old_message = jq('#message'),
+          message_wrapper = jq('#messageWrapper');
+
+      // insert a new, cloned message
+      message_wrapper.prepend(message_div);
+      message.find('dd').text(text);
+      message.css({opacity: 0}).show();
+      message.attr('id', 'message');
+
+      // animate message switch and remove old message
+      message_wrapper.animate({height: message.height() + 20 }, 400);
+      message.fadeTo(400, 1);
+      old_message.fadeTo(400, 0, function() {
+          old_message.parent().remove();
+      });
+  };
+
+  function submitHistoryForm() {
+       var form = document.history;
+       var path = form.path.options[form.path.selectedIndex].value;
+       form.action = path;
+       form.submit();
+  }
+
+  function pushToHistory(url) {
+    var history = jq(document).data('atrb_history');
+    history.push(url);
+    jq(document).data('atrb_history', history);
+  }
+
+  function resetHistory() {
+    jq(document).data('atrb_history', []);
+  }
+
+  function popFromHistory() {
+    var history = jq(document).data('atrb_history');
+    value = history.pop();
+    jq(document).data('atrb_history', history);
+    return value;
+  }
+
+  function refreshOverlay(wrap, srcfilter, newoption) {
+      var oldhistory = jq('[id^=atrb_] form#history select');
+      wrap.load(srcfilter, function() {
+          jq('[id^=atrb_] form#history select').append(newoption +
+                                                       oldhistory.html());
+          ov = jq('div#content').data('overlay');
+          widget_id = ov.getTrigger().attr('rel').substring(6);
+          disablecurrentrelations(widget_id);
+          var fieldname = wrap.find('input[name=fieldName]').attr('value');
+          check_referenced_items(fieldname);
+          });
+  }
+
+  // check all references in the overlay that are present in the widget
+  function check_referenced_items(fieldname) {
+      var refs_in_overlay = jq('input.insertreference'),
+          uid_selector = "input[name='" + fieldname + ":list']",
+          current = jq(uid_selector), // the widget in the form
+          current_uids = current.map(function () {
+              if (jq(this).attr('checked') === true) {
+                  return jq(this).attr('value');
+              }
+              return null;
+          });
+
+      refs_in_overlay.each(function () {
+          var overlay_ref = jq(this),
+              uid = jq(overlay_ref).attr('rel'),
+              i;
+
+          for (i = 0; i < current_uids.length; i++) {
+              if (uid === current_uids[i]) {
+                  overlay_ref.attr('checked', true);
+                  return true;  // break jq.each
+              }
+          }
+      });
+  }
+});

--- a/Products/Poi/skins/Poi/issuereference.js
+++ b/Products/Poi/skins/Poi/issuereference.js
@@ -118,6 +118,14 @@ jQuery(function(jq) {
       var search_index = wrap.find('select[name=search_index]').attr('value');
       var multi = wrap.find('input[name=multiValued]').attr('value');
       var close_window = wrap.find('input[name=close_window]').attr('value');
+
+      // display error message if no search terms are entered
+      if ((searchvalue == "") && (searchvaluetag == "") && (searchvalueid == "")) {
+          error = "Enter search criteria in the issue number, issue title, and/or tags fields.";
+          jq(".errorMessage").text(error).css("background-color", "#F7F7B9");
+          return false;
+      }
+
       qs = 'searchValue=' + searchvalue + '&searchValueTag=' + searchvaluetag + '&searchValueID=' + searchvalueid;
       // if a search_index is defined (a dropdown list of selectable indexes next to the search input), we insert it to qs
       if (search_index) {

--- a/Products/Poi/skins/Poi/issuereference.js
+++ b/Products/Poi/skins/Poi/issuereference.js
@@ -113,10 +113,12 @@ jQuery(function(jq) {
       var fieldrealname = wrap.find('input[name=fieldRealName]').attr('value');
       var at_url = wrap.find('input[name=at_url]').attr('value');
       var searchvalue = encodeURI(wrap.find('input[name=searchValue]').attr('value'));
+      var searchvaluetag = encodeURI(wrap.find('input[name=searchValueTag]').attr('value'));
+      var searchvalueid = encodeURI(wrap.find('input[name=searchValueID]').attr('value'));
       var search_index = wrap.find('select[name=search_index]').attr('value');
       var multi = wrap.find('input[name=multiValued]').attr('value');
       var close_window = wrap.find('input[name=close_window]').attr('value');
-      qs = 'searchValue=' + searchvalue;
+      qs = 'searchValue=' + searchvalue + '&searchValueTag=' + searchvaluetag + '&searchValueID=' + searchvalueid;
       // if a search_index is defined (a dropdown list of selectable indexes next to the search input), we insert it to qs
       if (search_index) {
           qs += '&search_index=' + search_index;

--- a/Products/Poi/skins/Poi/issuereference.pt
+++ b/Products/Poi/skins/Poi/issuereference.pt
@@ -1,0 +1,223 @@
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      i18n:domain="atreferencebrowserwidget">
+
+  <head><title></title></head>
+
+  <body>
+
+    <metal:view_macro define-macro="view">
+      <tal:define define="
+          image_portal_types field/widget/image_portal_types|string:;
+          image_method       field/widget/image_method|string:;
+          show_path          field/widget/show_path|nothing;
+          hide_inaccessible  field/widget/hide_inaccessible | nothing;
+          helper nocall:here/refbrowserhelper;
+          portal context/@@plone_portal_state/portal;
+          portal_path        helper/getPortalPath;
+          value python: field.getEditAccessor(context)();
+          refs python:helper.getFieldRelations(field, value);"
+          condition="refs">
+
+
+        <tal:notMultivalued condition="not:field/multiValued"> 
+        <tal:block condition="python: (can_view or not hide_inaccessible)"
+                   define="obj python:refs[0];
+                           obj_path python: '/'.join(obj.getPhysicalPath());
+                           can_view python: helper.canView(obj)">
+          <img src="#" alt="Image"
+              tal:condition="python: obj.portal_type in image_portal_types"
+              tal:attributes="src string:${obj/absolute_url}/$image_method"
+              />
+
+          <a href="#"
+              tal:attributes="href obj/absolute_url;
+                              class python:obj.portal_type.replace(' ', '_')"
+              tal:content="python:obj.Title() or obj.absolute_url(relative=1)"
+              >Sole target object's title</a>
+
+            <a href="#"
+               tal:condition="python:portal.portal_interface.objectImplements(obj,
+                        'Products.Archetypes.interfaces.referenceengine.IContentReference')"
+               tal:attributes="href python:ref.getContentObject().absolute_url();
+                               class python:obj.portal_type.replace(' ', '_')"
+               tal:content="field/relationship"
+               >reference object link</a>
+
+            <tal:if condition="show_path" i18n:translate="label_directory">
+              (Directory: <span i18n:name="directory"
+                                 tal:replace="python: obj_path.replace(portal_path + '/', '')"
+                                 >directory</span>)
+            </tal:if>
+
+        </tal:block>
+        </tal:notMultivalued> 
+
+        <ul tal:condition="field/multiValued">
+          <tal:block tal:repeat="obj refs">
+            <tal:block define="obj_path python: '/'.join(obj.getPhysicalPath());
+                               can_view python: helper.canView(obj)"
+                       condition="python: can_view or not hide_inaccessible">
+              <li>
+                <img tal:condition="python:obj.portal_type in image_portal_types"
+                    tal:attributes="src string:${obj/absolute_url}/$image_method" />
+                <a href="#"
+                    tal:attributes="
+                        href obj/absolute_url;
+                        class python:obj.portal_type.replace(' ', '_')"
+                    tal:content="
+                        python:obj.Title() or obj.absolute_url(relative=1)"
+                    >Target Title</a>
+
+                <a href="#"
+                    tal:condition="python:portal.portal_interface.objectImplements(obj,
+                        'Products.Archetypes.interfaces.referenceengine.IContentReference')"
+                    tal:attributes="href python:ref.getContentObject().absolute_url();
+                                    class python:obj.portal_type.replace(' ', '_')"
+                    tal:content="field/relationship"
+                    >reference object link</a>
+
+                <tal:if condition="show_path"
+                     i18n:translate="label_directory">
+                     (Directory: <span i18n:name="directory"
+                                        tal:replace="python: obj_path.replace(portal_path + '/', '') "
+                                         >directory</span>)
+                </tal:if>
+              </li>
+            </tal:block>
+          </tal:block>
+        </ul>
+
+      </tal:define>
+    </metal:view_macro>
+
+    <metal:reference_edit
+        define-macro="reference_edit"
+        tal:define="show_path          field/widget/show_path|nothing;
+                    image_portal_types widget/image_portal_types|string:;
+                    image_method       widget/image_method|string:;
+                    helper nocall:here/refbrowserhelper;
+                    portal_path        helper/getPortalPath;
+                    multiValued python:test(field.multiValued, 1, 0);
+                    refs python:helper.getFieldRelations(field, value);
+                    overlay_id string:atrb_${fieldName}">
+
+      <input type="hidden" value=""
+          tal:condition="multiValued"
+          tal:attributes="name string:$fieldName:default:list"
+          />
+
+      <tal:single tal:condition="not:multiValued" >
+        <tal:value tal:condition="value">
+          <tal:block tal:define="
+              obj python:refs[0];
+              obj_path python: '/'.join(obj.getPhysicalPath())" >
+
+            <input size="" type="text" value="" id="" readonly="readonly"
+                tal:attributes="
+                    value obj/title_or_id;
+                    size python:test(widget.size=='', 30, widget.size);
+                    id string:ref_browser_${fieldName}_label"
+                    />
+
+            <img tal:condition="python: obj.portal_type in image_portal_types"
+                 tal:attributes="src string:${obj/absolute_url}/$image_method"
+                 />
+
+            <tal:if condition="show_path" i18n:translate="label_directory">
+                (Directory: <span i18n:name="directory"
+                                  tal:replace="python: obj_path.replace(portal_path + '/', '')"
+                                  >directory</span>)
+            </tal:if>
+
+          </tal:block>
+        </tal:value>
+        <input id="" size="50" type="text" readonly="readonly"
+               value="No reference set. Click the add button to select."
+               i18n:attributes="value label_no_reference_set;"
+               tal:condition="not:value"
+               tal:attributes="id string:ref_browser_${fieldName}_label"
+               />
+        <input type="hidden" value="" name=""
+               tal:attributes="name fieldName;
+                               value value;
+                               id string:ref_browser_${fieldName}"
+              />
+
+      </tal:single>
+      <tal:multi tal:condition="multiValued">
+
+        <input type="hidden" value="0"
+            tal:attributes="name string:$fieldName-sortable;
+                            value python:test(widget.allow_sorting, 1, 0);"
+            />
+
+        <div style="float: left"> <!-- don't remove this. it is needed for DOM traversal -->
+
+          <ul class="visualNoMarker"
+              tal:attributes="id string:ref_browser_items_${fieldName};"
+              tal:condition="refs">
+            <li tal:repeat="set refs"
+                tal:attributes="
+                  id string:ref-${fieldName}-${repeat/set/index};">
+              <label tal:define="
+                   title set/title_or_id | string:Undisclosed;
+                   obj_path python: '/'.join(set.getPhysicalPath());">
+                <input type="checkbox"
+                       tal:attributes="name string:${fieldName}:list;
+                                       value python:helper.getUidFromReference(set);"
+                       checked="checked" />
+                <tal:block replace="python: show_path and '%s (%s)' % (title, obj_path.replace(portal_path, '')) or title" />
+              </label>
+
+              <tal:sorting condition="widget/allow_sorting">
+                <a href="" title="Move up"
+                    onclick="javascript:refbrowser_moveReferenceUp(this); return false">&#x25b2;</a>
+                <a href="" title="Move down"
+                    onclick="javascript:refbrowser_moveReferenceDown(this); return false">&#x25bc;</a>
+              </tal:sorting>
+
+            </li>
+          </ul>
+        </div>
+      </tal:multi>
+      <div style="clear: both"
+          tal:define="
+              at_url helper/getAtURL;
+              startup_directory python:helper.getStartupDirectory(field)">
+        Add:<input type="button" class="searchButton addreference" value="Add..."
+               i18n:attributes="value label_add;"
+               tal:define="popup_width widget/popup_width|string:500;
+                           popup_height widget/popup_height|string:550;"
+               tal:attributes="src string:${startup_directory}/refbrowser_popup?fieldName=${fieldName}&amp;fieldRealName=${field/getName}&amp;at_url=${at_url};
+                           rel string:#${overlay_id}" />
+        <input type="button" class="destructive" value="Clear reference" onclick=""
+               i18n:attributes="value label_remove_reference;"
+               tal:condition="not:multiValued"
+               tal:attributes="onclick string:javascript:refbrowser_removeReference('ref_browser_${fieldName}', ${multiValued})" />
+           </div><div id="atrb" tal:attributes="id overlay_id" class="overlay overlay-ajax"><div class="close"><span>Close</span></div>
+           <div class="pb-ajax">
+             <!-- <a href="" i18n:translate="referencebrowser_back" class="refbrowser_back">Back</a> -->
+             <div class="overlaycontent" style="font-size: 125%"></div>
+             <!-- <a href="" i18n:translate="referencebrowser_back" class="refbrowser_back">Back</a> -->
+           </div>
+           </div>
+      <!-- Todo? -->
+      <metal:addable metal:use-macro="here/widgets/addable_support/macros/addable"/>
+    </metal:reference_edit>
+
+    <metal:edit_macro define-macro="edit">
+      <metal:use use-macro="field_macro | here/widgets/field/macros/edit">
+        <metal:fill fill-slot="widget_body">
+          <metal:use use-macro="here/issuereference/macros/reference_edit" />
+        </metal:fill>
+      </metal:use>
+    </metal:edit_macro>
+
+    <metal:search_macro define-macro="search">
+      <div metal:use-macro="here/widgets/reference/macros/edit"></div>
+    </metal:search_macro>
+  </body>
+</html>

--- a/Products/Poi/skins/Poi/issuereference.pt
+++ b/Products/Poi/skins/Poi/issuereference.pt
@@ -14,7 +14,7 @@
           image_method       field/widget/image_method|string:;
           show_path          field/widget/show_path|nothing;
           hide_inaccessible  field/widget/hide_inaccessible | nothing;
-          helper nocall:here/refbrowserhelper;
+          helper nocall:here/issuerefhelper;
           portal context/@@plone_portal_state/portal;
           portal_path        helper/getPortalPath;
           value python: field.getEditAccessor(context)();
@@ -98,7 +98,7 @@
         tal:define="show_path          field/widget/show_path|nothing;
                     image_portal_types widget/image_portal_types|string:;
                     image_method       widget/image_method|string:;
-                    helper nocall:here/refbrowserhelper;
+                    helper nocall:here/issuerefhelper;
                     portal_path        helper/getPortalPath;
                     multiValued python:test(field.multiValued, 1, 0);
                     refs python:helper.getFieldRelations(field, value);
@@ -191,7 +191,7 @@
                i18n:attributes="value label_add;"
                tal:define="popup_width widget/popup_width|string:500;
                            popup_height widget/popup_height|string:550;"
-               tal:attributes="src string:${startup_directory}/refbrowser_popup?fieldName=${fieldName}&amp;fieldRealName=${field/getName}&amp;at_url=${at_url};
+               tal:attributes="src string:${startup_directory}/issueref_popup?fieldName=${fieldName}&amp;fieldRealName=${field/getName}&amp;at_url=${at_url};
                            rel string:#${overlay_id}" />
         <input type="button" class="destructive" value="Clear reference" onclick=""
                i18n:attributes="value label_remove_reference;"

--- a/Products/Poi/skins/Poi/issuereference.pt
+++ b/Products/Poi/skins/Poi/issuereference.pt
@@ -169,6 +169,9 @@
                        tal:attributes="name string:${fieldName}:list;
                                        value python:helper.getUidFromReference(set);"
                        checked="checked" />
+                <tal:issue condition="set/id">
+                    #<span tal:replace="set/id">#123</span> --
+                </tal:issue>
                 <tal:block replace="python: show_path and '%s (%s)' % (title, obj_path.replace(portal_path, '')) or title" />
               </label>
 
@@ -187,7 +190,7 @@
           tal:define="
               at_url helper/getAtURL;
               startup_directory python:helper.getStartupDirectory(field)">
-        Add:<input type="button" class="searchButton addreference" value="Add..."
+        <input type="button" class="searchButton addreference" value="Search and Add..."
                i18n:attributes="value label_add;"
                tal:define="popup_width widget/popup_width|string:500;
                            popup_height widget/popup_height|string:550;"

--- a/Products/Poi/skins/Poi/poi.css.dtml
+++ b/Products/Poi/skins/Poi/poi.css.dtml
@@ -153,6 +153,10 @@ ul.issue-tags-tags a {
     display: inline;
 }
 
+#related-issues {
+    margin-bottom: 1.5em;
+}
+
 /* Different response types */
 
 .response-clarification {

--- a/Products/Poi/skins/Poi/poi_issue_search_form.pt
+++ b/Products/Poi/skins/Poi/poi_issue_search_form.pt
@@ -266,6 +266,13 @@
                    i18n:translate="poi_match_all_tags">Match all tags</label>
           </div>
 
+          <div>
+            <input type="checkbox" name="display_related"
+                   id="display_related" />
+            <label for="display_related"
+                   i18n:translate="poi_display_related">Include Related Issues</label>
+          </div>
+
           <div class="formControls">
             <input class="context searchButton"
                    type="submit"

--- a/Products/Poi/skins/Poi/poi_issue_search_results.pt
+++ b/Products/Poi/skins/Poi/poi_issue_search_results.pt
@@ -39,6 +39,7 @@
         <th i18n:translate="listingheader_severity">Severity</th>
         <th i18n:translate="listingheader_responsible">Responsible</th>
         <th i18n:translate="listingheader_tags">Tags</th>
+        <th i18n:translate="listingheader_related">Related Issue(s)</th>
         <th i18n:translate="listingheader_state">State</th>
       </tr>
     </thead>
@@ -84,6 +85,13 @@
                             style="text-align:center">&#8212;</div>
                    </td>
                    <td tal:content="python:', '.join(item.Subject)" />
+                   <td tal:define="obj item/getObject">
+                       <tal:related repeat="relate obj/getRelatedIssue">
+                           <a tal:content="string:#${relate/id}"
+                              tal:attributes="href relate/absolute_url;
+                                              title relate/Title" />
+                       </tal:related>
+                   </td>
                    <td>
                        <a tal:content="python:states.getValue(item.review_state)"
                           tal:attributes="href string:${here/absolute_url}/poi_issue_search?state=${item/review_state};

--- a/Products/Poi/skins/Poi/poi_issue_search_results.pt
+++ b/Products/Poi/skins/Poi/poi_issue_search_results.pt
@@ -26,7 +26,8 @@
                     (trackerUrl, '&amp;state='.join(activeStates),);
                   pas_member context/@@pas_member;
                   can_edit python:checkPermission('Modify portal content', here);
-                  releases here/getReleasesVocab;"
+                  releases here/getReleasesVocab;
+                  display_related request/display_related|nothing"
        tal:condition="nocall:issues">
        <thead>
       <tr>
@@ -39,7 +40,8 @@
         <th i18n:translate="listingheader_severity">Severity</th>
         <th i18n:translate="listingheader_responsible">Responsible</th>
         <th i18n:translate="listingheader_tags">Tags</th>
-        <th i18n:translate="listingheader_related">Related Issue(s)</th>
+        <th tal:condition="display_related"
+            i18n:translate="listingheader_related">Related Issue(s)</th>
         <th i18n:translate="listingheader_state">State</th>
       </tr>
     </thead>
@@ -85,7 +87,8 @@
                             style="text-align:center">&#8212;</div>
                    </td>
                    <td tal:content="python:', '.join(item.Subject)" />
-                   <td tal:define="obj item/getObject">
+                   <td tal:define="obj item/getObject"
+                       tal:condition="display_related">
                        <tal:related repeat="relate obj/getRelatedIssue">
                            <a tal:content="string:#${relate/id}"
                               tal:attributes="href relate/absolute_url;

--- a/Products/Poi/skins/Poi/poi_issue_view.pt
+++ b/Products/Poi/skins/Poi/poi_issue_view.pt
@@ -212,6 +212,20 @@
     </div>
 
     <div class="visualClear"><!----></div>
+    
+    <div id="related-issues"
+         tal:define="related python:here.getRelatedIssue()"
+         tal:condition="related">
+        <h3>Current Issue(s):</h3>
+        <ul>
+            <li tal:repeat="relate related">
+                <a href="" tal:attributes="href relate/absolute_url">
+                    #<span tal:replace="relate/id">123</span> --
+                    <span tal:replace="relate/Title">Issue Title</span>
+                </a>
+            </li>
+        </ul>
+    </div>
 
     <div tal:replace="structure provider:poi.response.add" />
 

--- a/Products/Poi/widgets.py
+++ b/Products/Poi/widgets.py
@@ -36,7 +36,7 @@ class IssueReferenceWidget(ReferenceWidget):
         'hide_inaccessible': 0,
         'popup_width': 500,
         'popup_height': 550,
-        'popup_name': 'popup',
+        'popup_name': 'issuepopup',
         'browsable_types': (),
         'top_popup_helper': None,
         'bottom_popup_helper': None,

--- a/Products/Poi/widgets.py
+++ b/Products/Poi/widgets.py
@@ -1,0 +1,158 @@
+from types import StringType
+
+from Acquisition import aq_base, aq_inner
+from AccessControl import ClassSecurityInfo
+
+from Products.Archetypes.utils import shasattr
+from Products.Archetypes.Registry import registerWidget,registerPropertyType
+from Products.Archetypes.Widget import ReferenceWidget
+
+
+class IssueReferenceWidget(ReferenceWidget):
+    _properties = ReferenceWidget._properties.copy()
+    _properties.update({
+        'macro': "issuereference",
+        'size': '',
+        'helper_js': ('issuereference.js',),
+        'default_search_index': 'SearchableText',
+        'show_indexes': 0,
+        'available_indexes': {},
+        'allow_search': 1,
+        'allow_browse': 1,
+        'startup_directory': '',
+        'startup_directory_method': '',
+        'base_query': '',
+        'force_close_on_insert': 0,
+        'search_catalog': 'portal_catalog',
+        'allow_sorting': 0,
+        'show_review_state': 0,
+        'show_path': 0,
+        'only_for_review_states': None,
+        'image_portal_types': (),
+        'image_method': None,
+        'history_length': 0,
+        'restrict_browsing_to_startup_directory': 0,
+        'show_results_without_query': 0,
+        'hide_inaccessible': 0,
+        'popup_width': 500,
+        'popup_height': 550,
+        'popup_name': 'popup',
+        'browsable_types': (),
+        'top_popup_helper': None,
+        'bottom_popup_helper': None,
+        })
+
+    # for documentation of properties see: README.txt
+    security = ClassSecurityInfo()
+
+    security.declarePublic('getStartupDirectory')
+    def getStartupDirectory(self, instance, field):
+        """get widget startup directory
+        """
+        url_tool = instance.restrictedTraverse('@@plone_tools').url()
+        basepath = '/'.join(url_tool.getRelativeContentPath(instance))
+        directory = ''
+        if getattr(self, 'startup_directory_method', None):
+            # First check that the method exists and isn't inherited.
+            method = getattr(aq_base(instance), self.startup_directory_method,
+                             False)
+            if method:
+                # Then get the method again, but with acquisition context this
+                # time:
+                method = getattr(instance, self.startup_directory_method, False)
+                if callable(method):
+                    method = method()
+
+                directory = method
+
+        elif getattr(self, 'startup_directory', None):
+            directory = self.startup_directory
+            if not directory.startswith('/'):
+                directory = '/'.join([basepath, directory])
+
+        else:
+            directory = basepath
+
+        return directory
+
+    security.declarePublic('getBaseQuery')
+    def getBaseQuery(self, instance, field):
+        """Return base query to use for content search
+        """
+        query = self.base_query
+        if query:
+            if type(query) is StringType and shasattr(instance, query):
+                method = getattr(instance, query)
+                results = method()
+            elif callable(query):
+                results = query()
+            elif isinstance(query,dict):
+                results = query
+            else:
+                raise ValueError("Wrong format for reference widget base_query parameter")
+        else:
+            results = {}
+
+        # If browser browse is restricted to startup_directory
+        # restrict search to it
+        if getattr(self, 'restrict_browsing_to_startup_directory', False):
+            startup_directory = self.getStartupDirectory(instance, field)
+            try:
+                startup_directory = aq_inner(instance.restrictedTraverse(startup_directory))
+                results['path'] = '/'.join(startup_directory.getPhysicalPath())
+            except KeyError:
+                pass
+
+        # Add portal type restrictions based on settings in field, if not part
+        # of original base_query the template tries to do this, but ignores
+        # allowed_types_method, which should override allowed_types
+        if not results.has_key('portal_type'):
+            allowed_types = getattr(field, 'allowed_types', ())
+            allow_method = getattr(field, 'allowed_types_method', None)
+            if allow_method is not None:
+                meth = getattr(instance, allow_method)
+                allowed_types = meth()
+
+            results['portal_type'] = allowed_types# + self.browsable_types
+
+        return results
+
+    security.declarePublic('process_form')
+    def process_form(self, instance, field, form, empty_marker=None,
+                     emptyReturnsMarker=False, validating=True):
+        """Basic impl for form processing in a widget
+        """
+        result = super(IssueReferenceWidget,
+                       self).process_form(instance, field, form, empty_marker,
+                                          emptyReturnsMarker, validating)
+        # when removing all items from a required reference-field we get a
+        # default form value of [''].  here we inject a 'custom' empty-value
+        # to trigger the isempty-validator and not use the previous content of
+        # the field.
+        if field.required and field.multiValued and \
+           not emptyReturnsMarker and result == ([''], {}):
+            return [], {}
+
+        return result
+
+registerWidget(IssueReferenceWidget,
+               title='Issue Reference Browser',
+               description=('Reference widget that allows you to browse or '
+                            'search the portal for objects to refer to.'),
+               used_for=('Products.Archetypes.Field.ReferenceField',)
+               )
+
+registerPropertyType('default_search_index', 'string', IssueReferenceWidget)
+registerPropertyType('show_index_selector', 'boolean', IssueReferenceWidget)
+registerPropertyType('available_indexes', 'dictionary', IssueReferenceWidget)
+registerPropertyType('allow_search', 'boolean', IssueReferenceWidget)
+registerPropertyType('allow_browse', 'boolean', IssueReferenceWidget)
+registerPropertyType('allow_sorting', 'boolean', IssueReferenceWidget)
+registerPropertyType('startup_directory', 'string', IssueReferenceWidget)
+registerPropertyType('restrict_browsing_to_startup_directory',
+                     'boolean', IssueReferenceWidget)
+registerPropertyType('search_catalog', 'string', IssueReferenceWidget)
+registerPropertyType('image_portal_types', 'lines', IssueReferenceWidget)
+registerPropertyType('image_method', 'string', IssueReferenceWidget)
+registerPropertyType('force_close_on_insert',
+                     'boolean', IssueReferenceWidget)

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(name='Products.Poi',
           'Products.AddRemoveWidget>=1.4.2',
           'Products.DataGridField>=1.8b1',
           'collective.watcherlist>=0.2',
+          'Products.PopupCalendarWidget',
+          'Products.OrderableReferenceField',
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
Implement the Related Issues feature. This was created for Archetypes, so some work will need to be done to make it work in Dexterity.

The field allows the user to mark issues that are related. The relation is shown on both the original issue and related issue.