### PR TITLE
Fixed `poi.js` javascript for newer jQuery versions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog for Poi
 2.2.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fixed ``poi.js`` javascript for newer jQuery versions.  1.9 would
+  fall over an undefined ``jQuery.browser``.  1.7 would fall over an
+  unrecognized expression, needing extra quotes.  Still works on 1.4.
+  Fixes `issue 30 <https://github.com/collective/Products.Poi/issues/30>`_.
+  [maurits]
 
 
 2.2.9 (2016-12-09)

--- a/Products/Poi/browser/resources/poi.js
+++ b/Products/Poi/browser/resources/poi.js
@@ -1,15 +1,11 @@
 jQuery(function($) {
-    // No overlays for IE6
-    if (!jQuery.browser.msie ||
-        parseInt(jQuery.browser.version, 10) >= 7) {
-
-        // Set up overlays
-        $('#poi-login-form').prepOverlay({
-            subtype: 'ajax',
-            filter: '#content>*',
-            formselector: '#content-core > form',
-            noform: 'reload',
-            closeselector: '[name=form.buttons.cancel]',
-        });
-    }
+  'use strict';
+  // Set up overlays
+  $('#poi-login-form').prepOverlay({
+    subtype: 'ajax',
+    filter: '#content>*',
+    formselector: '#content-core > form',
+    noform: 'reload',
+    closeselector: '[name="form.buttons.cancel"]',
+  });
 });


### PR DESCRIPTION
1.9 would fall over an undefined `jQuery.browser`.
1.7 would fall over an unrecognized expression, needing extra quotes.
Still works on 1.4.

Fixes issue #30.

cc @keul 