### PR TITLE
Fixed response attachments code to nicely display both blob and non-blobs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog for Poi
 2.3.1 (unreleased)
 ------------------
 
+- Fixed response attachments code to nicely display both blob and non-blob files.
+  [maurits]
+
 - Note: Products.Poi 2.x is only for Plone 4.  [maurits]
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,6 +21,8 @@ use the -c option to specify an alternate configuration file.
 import os, shutil, sys, tempfile, urllib, urllib2, subprocess
 from optparse import OptionParser
 
+__version__ = '1.x-2017-10-27'
+
 if sys.platform == 'win32':
     def quote(c):
         if ' ' in c:
@@ -69,9 +71,8 @@ for k, v in sys.modules.items():
 
 is_jython = sys.platform.startswith('java')
 
-setuptools_source = 'http://peak.telecommunity.com/dist/ez_setup.py'
-distribute_source = 'http://python-distribute.org/distribute_setup.py'
-
+setuptools_source = 'https://bootstrap.pypa.io/ez_setup.py'
+distribute_source = 'https://bitbucket.org/pypa/setuptools/raw/f657df1f1ed46596d236376649c99a470662b4ba/distribute_setup.py'
 
 # parsing arguments
 def normalize_to_url(option, opt_str, value, parser):

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,4 +1,5 @@
 [buildout]
+index = https://pypi.python.org/simple/
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.x.cfg
 package-name = Products.Poi


### PR DESCRIPTION
It looks like poi.receivemail still saves non blobs (which is something I should pick up).
They would get shown without a filename, which made it hard to click on them.