### PR TITLE
Make response attachment info prettier.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,11 @@ Changelog for Poi
 2.3.1 (unreleased)
 ------------------
 
+- Make response attachment info prettier.
+  Translate the mimetype info into a user readable text.
+  Get the proper size, instead of zero.
+  [maurits]
+
 - Note: Products.Poi 2.x is only for Plone 4.  [maurits]
 
 

--- a/Products/Poi/browser/response.pt
+++ b/Products/Poi/browser/response.pt
@@ -65,9 +65,10 @@
         <img tal:attributes="src attachment/icon" />
         <a tal:attributes="href attachment/url"
            tal:content="attachment/filename" />
-        <span class="discreet">
+        <span class="discreet"
+          tal:define="doc_type python:context.lookupMime(attachment['content_type'])">
           &#8212;
-          <tal:type content="attachment/content_type" />,
+          <tal:type content="doc_type" />,
           <tal:size content="attachment/size" />
         </span>
       </div>

--- a/Products/Poi/browser/response.py
+++ b/Products/Poi/browser/response.py
@@ -148,7 +148,7 @@ class Base(BrowserView):
             icon = context.getIcon()
         content_type = getattr(
             attachment, 'contentType', 'application/octet-stream')
-        size = getattr(attachment, 'get_size', 0)
+        size = getattr(attachment, 'getSize', 0)
         if callable(size):
             size = size()
         lookup = mtr.lookup(content_type)


### PR DESCRIPTION
Translate the mimetype info into a user readable text.
Get the proper size, instead of zero. It looks like we were expecting a non-blob.