### PR TITLE
Check if send_emails is True before sending mails for changes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog for Poi
 2.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Check if send_emails is True before sending mails for changes.
+  [maurits]
 
 
 2.3.1 (2017-10-31)

--- a/Products/Poi/events.py
+++ b/Products/Poi/events.py
@@ -137,9 +137,13 @@ def mail_issue_change(object, event):
     """
     if event.transition and event.transition.id == 'post':
         watchers = IWatcherList(object)
+        if not watchers.send_emails:
+            return
         watchers.send('new-issue-mail')
     elif event.new_state.id == 'resolved':
         watchers = IWatcherList(object)
+        if not watchers.send_emails:
+            return
         # Only mail the original poster, if available.
         address = object.getContactEmail()
         if address:
@@ -174,4 +178,6 @@ def addedNewStyleResponse(object, event):
 def sendResponseNotificationMail(issue):
     # As we take the last response by default, we can keep this simple.
     watchers = IWatcherList(issue)
+    if not watchers.send_emails:
+        return
     watchers.send('new-response-mail')


### PR DESCRIPTION
In some cases this was done automatically, but not everywhere.
Case in point: I made a script to transition lots of old issues to done, and disabled sending notifications,
but lots of mails were still sent (locally).