### PR TITLE
Vocab fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog for Poi
 ------------------
 
 - Fixed several internationalization problems.  [maurits]
+- Allow for graceful handling of missing vocab terms [cdw9]
 
 
 4.0 (2017-07-18)

--- a/Products/Poi/content/issue.py
+++ b/Products/Poi/content/issue.py
@@ -254,13 +254,17 @@ class Issue(Container):
 
     def display_area(self):
         tracker = self.getTracker()
-        areas = possibleAreas(tracker)
-        return areas.by_value[self.area].title
+        area = possibleAreas(tracker).by_value.get(self.area)
+        if area:
+            return area.title
+        return self.area + ' (missing)'
 
     def display_issue_type(self):
         tracker = self.getTracker()
-        issue_types = possibleIssueTypes(tracker)
-        return issue_types.by_value[self.issue_type].title
+        issue_type = possibleIssueTypes(tracker).by_value.get(self.issue_type)
+        if issue_type:
+            return issue_type.title
+        return self.issue_type + ' (missing)'
 
     def isWatching(self):
         """

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,6 +1,7 @@
 [buildout]
+index = https://pypi.org/simple/
 extends =
-    https://raw.github.com/collective/buildout.plonetest/master/test-5.x.cfg
+    https://raw.github.com/collective/buildout.plonetest/master/test-5.0.x.cfg
 package-name = Products.Poi
 package-extras = [test]
 extensions = mr.developer
@@ -26,16 +27,14 @@ eggs = ${instance:eggs}
 
 [versions]
 Products.AddRemoveWidget = 1.5.1
-Products.ArchAddOn = 1.7
 Products.DataGridField = 1.9.2
 Products.OrderableReferenceField = 1.2b4
-Products.PloneSoftwareCenter = 1.6.4
 Products.PrintingMailHost = 0.7
 collective.dexteritytextindexer = 2.1.1
 buildout.dumppickedversions = 0.5
 cioppino.twothumbs = 1.7
-collective.watcherlist = 3.0
+collective.watcherlist = 3.0.1
 contentratings = 1.1
 plone.contentratings = 1.1
-zc.buildout = 2.9.4
-setuptools = 12.0.5 
+zc.buildout = 2.9.5
+setuptools = 33.1.1


### PR DESCRIPTION
If an area or issue type is removed from the Tracker, any issues with those values are no longer accessible, they only throw an error. Also causes problems with the CSV export. This will prevent the errors from displaying to the user, and append '(missing)' to the value