### PR TITLE
avoid automatic setting for contact email field

### DIFF
--- a/Products/Poi/content/issue.py
+++ b/Products/Poi/content/issue.py
@@ -59,11 +59,6 @@ def checkEmpty(value):
     return True if value is False else False
 
 
-@provider(schema.interfaces.IContextAwareDefaultFactory)
-def getContactEmail(context):
-    return api.user.get_current().getProperty('email') or ""
-    
-
 class IIssue(model.Schema):
     """Marker interface for Poi issue"""
 
@@ -157,7 +152,6 @@ class IIssue(model.Schema):
                       u"resolution is available. Note that your email "
                       u"address will not be displayed to others."),
         required=False,
-        defaultFactory=getContactEmail,
     )
 
     read_permission(watchers='Poi.ModifyIssueWatchers')


### PR DESCRIPTION
We think that would be better to revert the PR #52 since when a issue is created and the user has not a valid email set, the email validation led to the following error:

Traceback (innermost last):
  Module ZPublisher.WSGIPublisher, line 156, in transaction_pubevents
  Module ZPublisher.WSGIPublisher, line 338, in publish_module
  Module ZPublisher.WSGIPublisher, line 256, in publish
  Module ZPublisher.mapply, line 85, in mapply
  Module ZPublisher.WSGIPublisher, line 62, in call_object
  Module plone.z3cform.layout, line 63, in __call__
  Module plone.z3cform.layout, line 47, in update
  Module plone.dexterity.browser.add, line 141, in update
  Module plone.z3cform.fieldsets.extensible, line 65, in update
  Module plone.z3cform.patch, line 30, in GroupForm_update
  Module z3c.form.group, line 132, in update
  Module z3c.form.form, line 136, in updateWidgets
  Module z3c.form.field, line 277, in update
  Module z3c.form.browser.text, line 36, in update
  Module z3c.form.browser.widget, line 171, in update
  Module Products.CMFPlone.patches.z3c_form, line 47, in _wrapped
  Module z3c.form.widget, line 115, in update
  Module zope.schema._bootstrapfields, line 112, in __get__
  Module zope.schema._bootstrapfields, line 291, in validate
  Module plone.schema.email, line 33, in _validate
plone.schema.email.InvalidEmail
